### PR TITLE
compute summary statistics

### DIFF
--- a/climate_eda.ipynb
+++ b/climate_eda.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -103,7 +103,7 @@
        "4                14.84                          11.23  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -204,6 +204,49 @@
     "###### Lastly, we print inconsistent value.\n",
     "###### If we know the criterias for other columns, we can simply check for inconsistent values just by adding expected range/criteria in the dictionary `criteria`."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "               Year  Global Average Temperature (°C)  CO2 Concentration (ppm)  \\\n",
+      "count  1.048576e+06                     1.048576e+06             1.048576e+06   \n",
+      "mean   1.961505e+03                     1.449954e+01             3.500280e+02   \n",
+      "std    3.579736e+01                     8.661005e-01             4.042409e+01   \n",
+      "min    1.900000e+03                     1.300000e+01             2.800000e+02   \n",
+      "25%    1.930000e+03                     1.375000e+01             3.149900e+02   \n",
+      "50%    1.962000e+03                     1.450000e+01             3.500700e+02   \n",
+      "75%    1.993000e+03                     1.525000e+01             3.850200e+02   \n",
+      "max    2.023000e+03                     1.600000e+01             4.200000e+02   \n",
+      "\n",
+      "       Sea Level Rise (mm)  Arctic Ice Area (million km²)  \n",
+      "count         1.048576e+06                   1.048576e+06  \n",
+      "mean          1.499900e+02                   9.000896e+00  \n",
+      "std           8.657659e+01                   3.462551e+00  \n",
+      "min           0.000000e+00                   3.000000e+00  \n",
+      "25%           7.497000e+01                   6.000000e+00  \n",
+      "50%           1.500200e+02                   9.000000e+00  \n",
+      "75%           2.249300e+02                   1.200000e+01  \n",
+      "max           3.000000e+02                   1.500000e+01  \n"
+     ]
+    }
+   ],
+   "source": [
+    "summary_statistics = df.describe()\n",
+    "print(summary_statistics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Description  
This PR addresses **issue #4** by computing summary statistics using `df.describe()`. It provides key metrics like **mean, std, min, and max**.  

### Changes Made  
- Used `df.describe()` for summary statistics.  
- Printed the results for verification.  

### Checklist  
- [x] Code runs without errors.  
- [x] Addresses issue #4.  
